### PR TITLE
Automatically copy the css and js files across during install / update

### DIFF
--- a/atomic/script.php
+++ b/atomic/script.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * @copyright	Copyright (C) 2020 Ron Severdia. All rights reserved.
+ * @license		GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+
+class AtomicInstallerScript
+{	
+	/**
+	 * Called after any type of action
+	 *
+	 * @param   string  $route  Which action is happening (install|uninstall|discover_install|update)
+	 * @param   JAdapterInstance  $adapter  The object responsible for running this script
+	 *
+	 * @return  boolean  True on success
+	 */
+	public function postflight($route, JAdapterInstance $adapter)
+	{
+		$parent = $adapter->getParent();
+		$source = $parent->getPath('source');
+
+		// Initialize folders
+		$this->initFolders();
+
+		// Only copy over needed css files
+		$cssFiles = $this->getCssFiles($route, $source);
+		$this->copyFiles($cssFiles, JPATH_ROOT . '/templates/atomic/css');
+
+		// Only copy over needed js files
+		$jsFiles = $this->getJsFiles($route, $source);
+		$this->copyFiles($jsFiles, JPATH_ROOT . '/templates/atomic/js');
+	}
+
+	/**
+	 * Initializes necessary folders if they are not created yet
+	 *
+	 * @access	private
+	 */
+	private function initFolders()
+	{
+		$folders = [
+			JPATH_ROOT . '/templates/atomic/css',
+			JPATH_ROOT . '/templates/atomic/js'
+		];
+
+		foreach ($folders as $folder) {
+			if (!JFolder::exists($folder)) {
+				JFolder::create($folder);
+			}			
+		}
+	}
+
+	/**
+	 * Responsible to copy the files across from the source to the destination template folder
+	 *
+	 * @access	private
+	 */
+	private function copyFiles($files, $destination)
+	{
+		if (!$files) {
+			return false;
+		}
+
+		foreach ($files as $source) {
+			$target = $destination . '/' . basename($source);
+
+			JFile::copy($source, $target);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Responsible to determine which css files should be copied over
+	 *
+	 * @access	private
+	 */
+	private function getCssFiles($route, $source)
+	{
+		$exclusion = ['.svn', 'CVS', '.DS_Store', '__MACOSX'];
+
+		if ($route == 'update') {
+			$exclusion[] = 'template.css';
+		}
+
+		$cssFolder = $source . '/css';
+		$files = JFolder::files($cssFolder, '.', false, true, $exclusion);
+
+		return $files;
+	}
+
+	/**
+	 * Responsible to determine which js files should be copied over
+	 *
+	 * @access	private
+	 */
+	private function getJsFiles($route, $source)
+	{
+		$exclusion = ['.svn', 'CVS', '.DS_Store', '__MACOSX'];
+
+		if ($route == 'update') {
+			$exclusion[] = 'template.js';
+		}
+
+		$jsFolder = $source . '/js';
+		$files = JFolder::files($jsFolder, '.', false, true, $exclusion);
+
+		return $files;	
+	}
+}

--- a/atomic/templateDetails.xml
+++ b/atomic/templateDetails.xml
@@ -10,13 +10,12 @@
 	<copyright>Copyright (C) 2018-2020 Ron Severdia. All rights reserved.</copyright>
 	<license>GNU General Public License version 2 or later</license>
 	<description>Atomic is an easy-to-modify and minimal example of a Joomla template using Bootstrap, once included in Joomla 1.5.</description>
+	<scriptfile>script.php</scriptfile>
 	<files>
 		<folder>html</folder>
-		<folder>css</folder>
 		<folder>fonts</folder>
 		<folder>images</folder>
 		<folder>language</folder>
-		<folder>js</folder>
 		<folder>favicons</folder>
 		<filename>index.php</filename>
 		<filename>index.html</filename>


### PR DESCRIPTION
Automate file copying for css and js files using the manifest script file to avoid the template.css and template.js being overwritten during updates.